### PR TITLE
Updated bootstrap view to word-break sidebar file name and path

### DIFF
--- a/views/bootstrap/snapshot.php
+++ b/views/bootstrap/snapshot.php
@@ -1,4 +1,15 @@
 <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
+<style>
+    li.list-group-item p {
+        word-wrap: break-word;
+        word-break: break-word;
+    }
+
+    h4.list-group-item-heading {
+        word-wrap: break-word;
+        word-break: break-word;
+    }
+</style>
 <div class="col-sm-4">
     <ul class="list-group">
         <?php foreach ($snapshot->getItems() as $item): ?>


### PR DESCRIPTION
Updated bootstrap view to word-break sidebar file name and path, without word-break the file and path would overlap server/environment infomation
